### PR TITLE
mainBindfull: Fixed validation error VUID-VkBufferCreateInfo-None-09499

### DIFF
--- a/source/chapter2/mainBindfull.cpp
+++ b/source/chapter2/mainBindfull.cpp
@@ -48,6 +48,8 @@ int main(int argc, char* argv[]) {
 #endif
     VK_KHR_SWAPCHAIN_EXTENSION_NAME,
     VK_EXT_MEMORY_BUDGET_EXTENSION_NAME,
+    VK_KHR_ACCELERATION_STRUCTURE_EXTENSION_NAME,
+    VK_KHR_DEFERRED_HOST_OPERATIONS_EXTENSION_NAME,
   };
 
   std::vector<std::string> validationLayers;


### PR DESCRIPTION
Run `mainBindfull` in DEBUG build:

```
debugMessengerCallback : MessageCode is VUID-VkBufferCreateInfo-None-09499 &
Message is Validation Error: [ VUID-VkBufferCreateInfo-None-09499 ] |
MessageID = 0xeef3ffc7 | vkCreateBuffer(): pCreateInfo->usage (0xa0022) has VkBufferUsageFlagBits values that requires the extensions VK_KHR_acceleration_structure.
The Vulkan spec states: If the pNext chain does not include a VkBufferUsageFlags2CreateInfoKHR structure, usage must be a valid combination of VkBufferUsageFlagBits values
(https://vulkan.lunarg.com/doc/view/1.3.280.0/windows/1.3-extensions/vkspec.html#VUID-VkBufferCreateInfo-None-09499)
```