### PR TITLE
Utilize Context::createVkDevice() and cleanup duplicate code

### DIFF
--- a/source/vulkancore/Context.hpp
+++ b/source/vulkancore/Context.hpp
@@ -67,8 +67,8 @@ class Context final {
                    const std::vector<std::string>& requestedInstanceExtensions,
                    bool printEnumerations = false, const std::string& name = "");
 
-  void createVkDevice(VkPhysicalDevice vkPhysicalDevice,
-                      const std::vector<std::string>& requestedDeviceExtensions,
+  void createVkDevice(PhysicalDevice& physicalDevice,
+                      const std::vector<const char*>& enabledInstanceLayers,
                       VkQueueFlags requestedQueueTypes, const std::string& name = "");
 
   ~Context();


### PR DESCRIPTION
Using `Context::createVkDevice()` instead of the duplicated code present in `Context`'s constructor. This change will reduce a considerable amount of code from the `Context` constructor and make it easier to follow through.