### PR TITLE
Create only one queue per each queue family

### DIFF
--- a/source/vulkancore/PhysicalDevice.cpp
+++ b/source/vulkancore/PhysicalDevice.cpp
@@ -106,7 +106,11 @@ void PhysicalDevice::reserveQueues(VkQueueFlags requestedQueueTypes,
   // we treat each queue as independent and it can only be used either for
   // graphics/compute/transfer or sparse, this helps us with multithreading,
   // however if the device only have one queue for all, then because of this
-  // code we may not be able to create compute/transfer queues
+  // code we may not be able to create compute/transfer queues.
+  // Even though the GPU may offer multiple queues per family, our code doesn't
+  // use parallel submits or parallel queues; therefore, we are hardcoding the
+  // number of queues per each family to one, since we only use the first queue
+  // to submit our workloads.
   for (uint32_t queueFamilyIndex = 0;
        queueFamilyIndex < queueFamilyProperties_.size() && requestedQueueTypes != 0;
        ++queueFamilyIndex) {
@@ -116,14 +120,14 @@ void PhysicalDevice::reserveQueues(VkQueueFlags requestedQueueTypes,
                                            &supportsPresent);
       if (supportsPresent == VK_TRUE) {
         presentationFamilyIndex_ = queueFamilyIndex;
-        presentationQueueCount_ = queueFamilyProperties_[queueFamilyIndex].queueCount;
+        presentationQueueCount_ = 1;
       }
     }
     if (!graphicsFamilyIndex_.has_value() &&
         (requestedQueueTypes & queueFamilyProperties_[queueFamilyIndex].queueFlags) &
             VK_QUEUE_GRAPHICS_BIT) {
       graphicsFamilyIndex_ = queueFamilyIndex;
-      graphicsQueueCount_ = queueFamilyProperties_[queueFamilyIndex].queueCount;
+      graphicsQueueCount_ = 1;
       requestedQueueTypes &= ~VK_QUEUE_GRAPHICS_BIT;
       continue;
     }
@@ -132,7 +136,7 @@ void PhysicalDevice::reserveQueues(VkQueueFlags requestedQueueTypes,
         (requestedQueueTypes & queueFamilyProperties_[queueFamilyIndex].queueFlags) &
             VK_QUEUE_COMPUTE_BIT) {
       computeFamilyIndex_ = queueFamilyIndex;
-      computeQueueCount_ = queueFamilyProperties_[queueFamilyIndex].queueCount;
+      computeQueueCount_ = 1;
       requestedQueueTypes &= ~VK_QUEUE_COMPUTE_BIT;
       continue;
     }
@@ -141,7 +145,7 @@ void PhysicalDevice::reserveQueues(VkQueueFlags requestedQueueTypes,
         (requestedQueueTypes & queueFamilyProperties_[queueFamilyIndex].queueFlags) &
             VK_QUEUE_TRANSFER_BIT) {
       transferFamilyIndex_ = queueFamilyIndex;
-      transferQueueCount_ = queueFamilyProperties_[queueFamilyIndex].queueCount;
+      transferQueueCount_ = 1;
       requestedQueueTypes &= ~VK_QUEUE_TRANSFER_BIT;
       continue;
     }
@@ -150,7 +154,7 @@ void PhysicalDevice::reserveQueues(VkQueueFlags requestedQueueTypes,
         (requestedQueueTypes & queueFamilyProperties_[queueFamilyIndex].queueFlags) &
             VK_QUEUE_SPARSE_BINDING_BIT) {
       sparseFamilyIndex_ = queueFamilyIndex;
-      sparseQueueCount_ = queueFamilyProperties_[queueFamilyIndex].queueCount;
+      sparseQueueCount_ = 1;
       requestedQueueTypes &= ~VK_QUEUE_SPARSE_BINDING_BIT;
       continue;
     }


### PR DESCRIPTION
According to _Creating a Vulkan logical device_ in Chapter 1, we should use one queue per family and set its priority to 1.

If the GPU offers multiple queues per family, the current code will use all of them and set their priority to 1. This PR will fix that behaviour by only using one queue per family and setting its priority to 1, as per the book.

### Section from the book
![image](https://github.com/user-attachments/assets/b4b2e532-f265-4fa6-99f4-604f3cbe209a)
