### PR TITLE
Compare the full Vulkan version instead of the header version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,10 +19,11 @@ find_package(Vulkan REQUIRED SPIRV-Tools)
 # Download dependencies automatically
 include(FetchContent)
 
-if (VulkanHeaderVersion GREATER_EQUAL 275)
+# Comparing the current Vulkan version with 1.3.275
+if (VulkanHeaderVersion2 GREATER_EQUAL 13275)
   FetchContent_Declare(glslang
       GIT_REPOSITORY https://github.com/KhronosGroup/glslang
-      GIT_TAG vulkan-sdk-1.3.${VulkanHeaderVersion}.0)
+      GIT_TAG vulkan-sdk-${Vulkan_VERSION}.0)
   if (NOT glslang_POPULATED)
     set(ENABLE_OPT OFF)
   endif()


### PR DESCRIPTION
Previously, only the Vulkan header version was compared to fetch the correct glslang version, by assuming major and minor versions are 1.3.
As Vulkan 1.4 SDK is out, this approach will throw errors when running the CMake file. This PR fixes that issue.